### PR TITLE
fix: correct recursive call in addRegionPrefixToSidebarItems and impr…

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -8,6 +8,19 @@ import spec from '../public/argentina/openapi.json' with { type: 'json' }
 
 const sidebar = useSidebar({ spec })
 
+/**
+ * Recursively adds a region prefix to all sidebar item links.
+ * This ensures that sidebar navigation links include the correct region path.
+ * 
+ * @param {string} prefix - The region prefix to add (e.g., '/argentina')
+ * @param {Object} items - The sidebar items object containing an items array
+ * @param {Array} items.items - Array of sidebar item objects
+ * @returns {Object} Modified items object with prefixed links
+ * 
+ * @example
+ * // Input: prefix = '/argentina', items = { items: [{ link: '/api' }] }
+ * // Output: { items: [{ link: '/argentina/api' }] }
+ */
 function addRegionPrefixToSidebarItems(prefix, items) {
   return {
     items: items.items.map((item) => {
@@ -15,7 +28,7 @@ function addRegionPrefixToSidebarItems(prefix, items) {
         item.link = `${prefix}${item.link}`
 
       if (item.items)
-        item.items = addRegionPrefixToSidebarItems(item.items)
+        item.items = addRegionPrefixToSidebarItems(prefix, { items: item.items })
 
       return item
     }),
@@ -30,30 +43,30 @@ const operationsOnlyArgentina = [
 ]
 
 const sidebarItems = collect(regions)
-    .mapWithKeys(region => [
-      `/${region.slug}/`,
-      sidebar
-        .generateSidebarGroups()
-        .map(group => {
-          return {
-            ...group,
-            ...addRegionPrefixToSidebarItems(`/${region.slug}`, group),
-          }
-        })
-        .map(group => {
-          return {
-            ...group,
-            items: group.items.filter(item => {
-              if (region.slug === 'argentina') {
-                return true
-              }
+  .mapWithKeys(region => [
+    `/${region.slug}/`,
+    sidebar
+      .generateSidebarGroups()
+      .map(group => {
+        return {
+          ...group,
+          ...addRegionPrefixToSidebarItems(`/${region.slug}`, group),
+        }
+      })
+      .map(group => {
+        return {
+          ...group,
+          items: group.items.filter(item => {
+            if (region.slug === 'argentina') {
+              return true
+            }
 
-              return !operationsOnlyArgentina.some(path => item.link.includes(path))
-            }),
-          }
-        })
-    ])
-    .all()
+            return !operationsOnlyArgentina.some(path => item.link.includes(path))
+          }),
+        }
+      })
+  ])
+  .all()
 
 // https://vitepress.dev/reference/site-config
 export default defineConfig({

--- a/.vitepress/scripts/generateDocs.mjs
+++ b/.vitepress/scripts/generateDocs.mjs
@@ -10,26 +10,92 @@ async function init() {
         await copyRegions();
     } catch (error) {
         console.error('Error during initialization:', error);
+        process.exit(1);
     }
 }
 
+/**
+ * Generates OpenAPI specifications for each region by fetching exchange data
+ * from the CriptoYa API and replacing placeholders in the template specs.
+ */
 async function generateOpenApi() {
+    const errors = [];
+    let successCount = 0;
+
     for (const region of regions) {
-        const { slug } = region;
-        const path = `public/${slug}`;
-        await fs.mkdir(path, { recursive: true });
+        try {
+            const { slug, name, code } = region;
+            const path = `public/${slug}`;
+            await fs.mkdir(path, { recursive: true });
 
-        const regionsByExchanges = await fetch('https://criptoya.com/api/exchanges')
-            .then(response => response.json())
+            // Fetch exchanges with timeout to prevent hanging
+            const controller = new AbortController();
+            const timeoutId = setTimeout(() => controller.abort(), 10000); // 10s timeout
 
-        const regionExchanges = regionsByExchanges[region.code.toLowerCase()] || [];
+            let response;
+            try {
+                response = await fetch('https://criptoya.com/api/exchanges', {
+                    signal: controller.signal
+                });
+            } finally {
+                clearTimeout(timeoutId);
+            }
 
-        const specToUse = slug === 'argentina' ? specArgentina : spec;
-        const specString = JSON.stringify(specToUse)
-            .replace('"REPLACE_COTIZACION_EXCHANGE_ENUMS"', regionExchanges.map(exchange => `"${exchange}"`).join(','))
-            .replace('"REPLACE_COTIZACION_EXCHANGE_EXAMPLE"', `"${regionExchanges[0] || ''}"`);
+            if (!response.ok) {
+                throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+            }
 
-        await fs.writeFile(`${path}/openapi.json`, JSON.stringify(JSON.parse(specString), null, 4));
+            const regionsByExchanges = await response.json();
+
+            // Validate response format
+            if (!regionsByExchanges || typeof regionsByExchanges !== 'object') {
+                throw new Error('Invalid response format from exchanges API');
+            }
+
+            const regionExchanges = regionsByExchanges[code.toLowerCase()];
+
+            // Skip regions with no exchanges instead of using placeholders
+            if (!regionExchanges || !Array.isArray(regionExchanges) || regionExchanges.length === 0) {
+                console.warn(`⚠️  No exchanges found for ${name} (${code}), skipping...`);
+                continue;
+            }
+
+            // Select appropriate spec template
+            const specToUse = slug === 'argentina' ? specArgentina : spec;
+
+            // Replace placeholders with actual exchange data
+            const specString = JSON.stringify(specToUse)
+                .replace('"REPLACE_COTIZACION_EXCHANGE_ENUMS"',
+                    regionExchanges.map(exchange => `"${exchange}"`).join(','))
+                .replace('"REPLACE_COTIZACION_EXCHANGE_EXAMPLE"',
+                    `"${regionExchanges[0]}"`);
+
+            // Write generated spec to file
+            await fs.writeFile(`${path}/openapi.json`,
+                JSON.stringify(JSON.parse(specString), null, 4));
+
+            console.log(`✅ Generated OpenAPI spec for ${name}`);
+            successCount++;
+
+        } catch (error) {
+            const errorMsg = error.name === 'AbortError'
+                ? 'Request timeout'
+                : error.message;
+            console.error(`❌ Failed to generate docs for ${region.name}: ${errorMsg}`);
+            errors.push({ region: region.name, error: errorMsg });
+            // Continue with other regions instead of failing completely
+        }
+    }
+
+    // Summary report
+    console.log(`\n📊 Generation Summary:`);
+    console.log(`   ✅ Success: ${successCount}/${regions.length} regions`);
+
+    if (errors.length > 0) {
+        console.warn(`   ⚠️  Failed: ${errors.length} region(s)`);
+        errors.forEach(({ region, error }) => {
+            console.warn(`      - ${region}: ${error}`);
+        });
     }
 }
 


### PR DESCRIPTION
Fixes #7

Problem
Nested sidebar items were missing the region prefix in their links due to an incorrect recursive function call in 
.vitepress/config.mts

Solution
File: 
.vitepress/config.mts

Fixed recursive call to addRegionPrefixToSidebarItems by passing both required parameters
Added JSDoc documentation

File: .vitepress/scripts/generateDocs.mjs
Added 10-second timeout for API requests
Added validation for API response format
Skip regions with no exchanges instead of generating invalid specs
Added error reporting with summary statistics
Added JSDoc documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved documentation generation with enhanced error handling and regional support.
  * Fixed sidebar item prefixing to correctly display regional navigation across all documentation sections.

* **Improvements**
  * Strengthened resilience of documentation build process with better timeout management and per-region error tracking.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->